### PR TITLE
Build standalone exe file for Windows users

### DIFF
--- a/.github/workflows/compile-to-one-file.yml
+++ b/.github/workflows/compile-to-one-file.yml
@@ -1,0 +1,42 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Build standalone exe
+
+on:
+  push:
+    branches: [ experimental ]
+  pull_request:
+    types: [edited, submitted]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.12
+        cache: pip
+
+    # UV is the pip accelerator.
+    - name: Install dependencies
+      run: |
+        pip install --upgrade uv
+        uv pip install --system .
+        uv pip install --system nuitka
+
+    - name: Test the wheel build step ahead of packaging
+      run: uv build
+
+    # This is far more straight forward then the Nuitka-action.
+    - name: Compile to one exe file
+      run: >-
+        python -m nuitka
+        --include-package-data=mbotmake2.templates
+        --onefile
+        --assume-yes-for-downloads
+        mbotmake2

--- a/README.md
+++ b/README.md
@@ -29,15 +29,28 @@ Big notes for making your own config. Origin=middle, extruder absolute not relat
 
 <s>There is global variable at the top of mbotmake called DEBUG this will add each processed line as a "comment" into the jsontool path file I don't know if printing with all that in there will cause issues but it might so I recommend leaving it at False unless you are having weird issues and want to compare gcode-> jsontoolpath directly.</s>
 
-## Installation
-
-To be determined.
-
-<s>There is now a github action that generates a mbotmake.exe for windows users that don't want to have to get python working for this. I hope to eventual split the configuration for the different printers out to property files and come up with a way to change which is being used</s>
-
 <s>I'm adding my orcaslicer configuration for printer and process that seems to be working "well" I'm still having some issues but I think those a physical not gcode/makerbot code.</s>
 
 # Contributing
+## Installation
+
+### Windows users
+
+There is now a github action that generates a mbotmake.exe for windows users that don't want to have to get python working for this. I hope to eventual split the configuration for the different printers out to property files and come up with a way to change which is being used
+
+### Mac and Linux users
+
+Assuming the `UV` python package manager is installed on your computer, run the
+following commands to install the tool into virtual environment.
+
+```shell
+mkdir mbotmake/
+cd mbotmake/
+uv venv --python=3.12
+source .venv/bin/activate
+uv pip install -U git+https://github.com/charely6/mbotmake@experimental
+python3.12 -m mbotmake2 --help
+```
 
 ## Download and configure the project
 


### PR DESCRIPTION
Provide a github action to generate the standalone exe file. Don't publish it. Only validate the seamless build process on a Windows machine.