### PR TITLE
[Bugfix] Cast enum to string

### DIFF
--- a/mbotmake2/__main__.py
+++ b/mbotmake2/__main__.py
@@ -68,15 +68,15 @@ def parseArgs(argv: list[str]) -> tuple[Path, MachineType, ExtruderType]:
         "-m",
         "--machine",
         type=MachineType,
-        choices=[m.value for m in MachineType],
-        default=MachineType.REPLICATORPlUS.value,
+        choices=list(MachineType),
+        default=MachineType.REPLICATORPLUS.value,
         help="3D printer machine type",
     )
     parser.add_argument(
         "-e",
         "--extruder",
         type=ExtruderType,
-        choices=[m.value for m in ExtruderType],
+        choices=list(ExtruderType),
         default=ExtruderType.SMARTEXTRUDERPLUS.value,
         help="Extruder type",
     )

--- a/mbotmake2/metafile.py
+++ b/mbotmake2/metafile.py
@@ -98,7 +98,7 @@ def generateMetajson(
     match machinetype:
         case MachineType.REPLICATOR5:
             meta = metaJson5th(meta)
-        case MachineType.REPLICATORPlUS:
+        case MachineType.REPLICATORPLUS:
             meta = metaJsonPlus(meta)
         case MachineType.REPLICATORMINI:
             meta = metaJsonMini(meta)

--- a/mbotmake2/types.py
+++ b/mbotmake2/types.py
@@ -66,9 +66,12 @@ class PrinterSettings:
 
 class MachineType(Enum):
     REPLICATOR5 = "Rep5"
-    REPLICATORPlUS = "RepPlus"
+    REPLICATORPLUS = "RepPlus"
     REPLICATORMINI = "Mini5"
     REPLICATORMINIPLUS = "MiniPlus"
+
+    def __str__(self):
+        return self.value
 
 
 class ExtruderType(Enum):
@@ -76,3 +79,6 @@ class ExtruderType(Enum):
     SMARTEXTRUDERPLUS = "SmartExtPlus"
     TOUGHEXTRUDER = "ToughExt"
     EXPERIMENTALEXTRUDER = "ExperimentalExt"
+
+    def __str__(self):
+        return self.value


### PR DESCRIPTION
Resolve the error: `ExtruderType(Enum)` is not a command line option. Now we can execute `python -m mboxmake2 -m RepPlus -e SmartExtPlus` to specify the machine type and extruder type.

Finish the print with a comment json embedded in the field `{ "command": ...}`. 