### PR TITLE
Store the standalone exe file for 14 days

### DIFF
--- a/.github/workflows/compile-to-one-file.yml
+++ b/.github/workflows/compile-to-one-file.yml
@@ -40,3 +40,10 @@ jobs:
         --onefile
         --assume-yes-for-downloads
         mbotmake2
+    - name: Archive production artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: mbotmake-standalone-exe
+        path: mbotmake2.exe
+        if-no-files-found: error
+        retention-days: 14


### PR DESCRIPTION
For windows 64-bit targets, once the standalone exe file is successfully generated, uploaded the exe file to the temporary location and keep it for 14 days. Delete it after that to free up the github storage space. 