### PR TITLE
Expose the global Z offset

### DIFF
--- a/mbotmake2/transformers/toolpath.py
+++ b/mbotmake2/transformers/toolpath.py
@@ -22,7 +22,7 @@ class Logging:
 
 
 class ToolpathTransformer(NodeVisitor):
-    def __init__(self, global_z_offset: float = -0.05):
+    def __init__(self, global_z_offset: float):
         self.commands: list[Command] = []
 
         self.extruder_temperature: float | None = None


### PR DESCRIPTION
Expose the global z offset adjustment (default: -0.05 mmm) in the command line option. Previously (in `mbotmake v1`), it was hardcoded in the python script.

Note: The long term solution is to apply the z-offset setting in the slicer software itself, not in `mbotmake`.