### PR TITLE
Write output to output folder

### DIFF
--- a/mbotmake2/__main__.py
+++ b/mbotmake2/__main__.py
@@ -5,6 +5,7 @@ import tempfile
 import zipfile
 from dataclasses import asdict
 from itertools import islice
+from os import getenv
 from pathlib import Path
 
 from mbotmake2.extract_thumbnails import extractThumbnails
@@ -144,6 +145,13 @@ if __name__ == "__main__":
             )
             toolpathfile.write("\n]\n")
 
-        output_file = input_file.with_suffix(".makerbot")
+        # Determine the output path and output file name
+        preferred_output_name = getenv("SLIC3R_PP_OUTPUT_NAME")
+        output_file = (
+            input_file.with_suffix(".makerbot")
+            if preferred_output_name is None or len(preferred_output_name.strip()) == 0
+            else Path(preferred_output_name).with_suffix(".makerbot")
+        )
+
         print(f"Generating {output_file.name}...")
         packageMBotFile(output_file, temp_dir, thumbnail_paths)

--- a/tests/test_gcode_parsing.py
+++ b/tests/test_gcode_parsing.py
@@ -5,5 +5,5 @@ from mbotmake2.transformers.toolpath import ToolpathTransformer
 def test_prusa_gcode_file() -> None:
     with open("testcases/prusaslicer_gcode/cube.gcode", "r") as file:
         ast = grammar.parse(file.read())
-        transformer = ToolpathTransformer()
+        transformer = ToolpathTransformer(0.0)
         assert transformer.visit(ast)

--- a/tests/test_toolpath_parsing.py
+++ b/tests/test_toolpath_parsing.py
@@ -6,11 +6,13 @@ from mbotmake2.transformers.toolpath import ToolpathTransformer
 
 grammar = Grammar(STRICT + SYNTAX)
 
+ZERO_OFFSET = 0.0
+
 
 def test_FanDuty() -> None:
     ast = grammar.parse("M106 S183.6\n")
 
-    transformer = ToolpathTransformer()
+    transformer = ToolpathTransformer(ZERO_OFFSET)
     transformer.visit(ast)
     assert len(transformer.commands) == 1
     assert transformer.commands[0].function == "fan_duty"
@@ -20,7 +22,7 @@ def test_FanDuty() -> None:
 
 def test_SetFeedrate() -> None:
     ast = grammar.parse("G1 F7200\n")
-    transformer = ToolpathTransformer()
+    transformer = ToolpathTransformer(ZERO_OFFSET)
     transformer.visit(ast)
 
     assert transformer.feedrate == approx(7200 / 60.0)
@@ -29,7 +31,7 @@ def test_SetFeedrate() -> None:
 def test_MoveE() -> None:
     ast = grammar.parse("G1 E1.30602 F4200\n")
 
-    transformer = ToolpathTransformer()
+    transformer = ToolpathTransformer(ZERO_OFFSET)
     transformer.visit(ast)
     assert transformer.feedrate == approx(4200 / 60.0)
 
@@ -43,7 +45,7 @@ def test_MoveE() -> None:
 def test_Move2D() -> None:
     ast = grammar.parse("G1 X-5.625 Y-7.102 E3.29059\n")
 
-    transformer = ToolpathTransformer()
+    transformer = ToolpathTransformer(ZERO_OFFSET)
     transformer.feedrate = 1234
     transformer.visit(ast)
 
@@ -59,7 +61,7 @@ def test_Move2D() -> None:
 
 def test_ToggleFan() -> None:
     ast = grammar.parse("M107\n")
-    transformer = ToolpathTransformer()
+    transformer = ToolpathTransformer(ZERO_OFFSET)
     transformer.visit(ast)
     assert len(transformer.commands) == 1
     assert transformer.commands[0].function == "toggle_fan"
@@ -76,7 +78,7 @@ def test_ResetPosition() -> None:
     assert grammar.parse("G92 E0\n")
     ast = grammar.parse("G92 E0.0\n")
 
-    transformer = ToolpathTransformer()
+    transformer = ToolpathTransformer(ZERO_OFFSET)
     transformer.printer_offset.a = 123
     transformer.cursor.a = 321
     transformer.visit(ast)
@@ -90,7 +92,7 @@ def test_AbsolutePosition() -> None:
 def test_ToolheadTemperature() -> None:
     ast = grammar.parse("M104 S180\n")
 
-    transformer = ToolpathTransformer()
+    transformer = ToolpathTransformer(ZERO_OFFSET)
     transformer.visit(ast)
     assert transformer.extruder_temperature is not None
     assert transformer.extruder_temperature == approx(180)
@@ -100,7 +102,7 @@ def test_PrintingTime() -> None:
     assert grammar.parse("; estimated printing time (normal mode) = 28m 3s\n")
     ast = grammar.parse("; estimated printing time (normal mode) = 5h 28m 3s\n")
 
-    transformer = ToolpathTransformer()
+    transformer = ToolpathTransformer(ZERO_OFFSET)
     transformer.visit(ast)
     assert transformer.printing_time_s is not None
     assert transformer.printing_time_s == (5 * 3600 + 28 * 60 + 3)


### PR DESCRIPTION
If the environment variable `SLIC3R_PP_OUTPUT_NAME` is defined, write
the Makerbot file to the target path. Otherwise, write the same folder
as the input file. 

Minor edits:

- `ToolpathTransformer()` now requires a z_offset argument. Resolve unit test error.

Resolves #12 