### PR TITLE
Report that 3-axis move command is not implemented

### DIFF
--- a/mbotmake2/grammars/toolpath.py
+++ b/mbotmake2/grammars/toolpath.py
@@ -31,9 +31,10 @@ AbsolutePositioning = "G90"
 AbsolutePositioningForExtruders = "M82"
 ResetPosition = "G92 E" ("0.0" / "0")
 
-Move = "G1" (Coord2D / CoordE / CoordZ / Feedrate)
-CoordZ = " Z" Decimal Feedrate?
-Coord2D = " X" Decimal " Y" Decimal ExtruderPosition? Feedrate?
+Move = "G1" (Coord3D / Coord2D / CoordE / CoordZ / Feedrate)
+CoordZ = Z Decimal Feedrate?
+Coord2D = X Decimal Y Decimal ExtruderPosition? Feedrate?
+Coord3D = X Decimal Y Decimal Z Decimal Feedrate?
 CoordE = ExtruderPosition Feedrate
 
 ExtruderPosition = " E" Decimal
@@ -43,6 +44,9 @@ PrintingTime = ~r" estimated printing time [^=]*="i Hour? Minute? Second?
 Hour = " " Integer "h"
 Minute = " " Integer "m"
 Second = " " Integer "s"
+X = " X"
+Y = " Y"
+Z = " Z"
 
 Integer = ~"[0-9]+"i
 Decimal = ~r"-?(\d+\.\d+|\d+|\.\d+)"i

--- a/mbotmake2/transformers/toolpath.py
+++ b/mbotmake2/transformers/toolpath.py
@@ -144,6 +144,13 @@ class ToolpathTransformer(NodeVisitor):
             )
         )
 
+    def visit_Coord3D(self, node, _) -> None:
+        raise NotImplementedError(f"""Three-axis move command not supported: {node.text:s}
+
+Did you forget to disable the "sequential printing mode"?
+Reference: https://help.prusa3d.com/article/sequential-printing_124589
+""")
+
     def visit_Coord2D(self, _, visited_children) -> Coords:
         _, x, _, y, extruder_position, feedrate = visited_children
 

--- a/tests/test_toolpath_parsing.py
+++ b/tests/test_toolpath_parsing.py
@@ -1,5 +1,6 @@
+from parsimonious.exceptions import VisitationError
 from parsimonious.grammar import Grammar
-from pytest import approx
+from pytest import approx, raises
 
 from mbotmake2.grammars.toolpath import STRICT, SYNTAX
 from mbotmake2.transformers.toolpath import ToolpathTransformer
@@ -106,3 +107,14 @@ def test_PrintingTime() -> None:
     transformer.visit(ast)
     assert transformer.printing_time_s is not None
     assert transformer.printing_time_s == (5 * 3600 + 28 * 60 + 3)
+
+
+def test_3d_diagonal_move() -> None:
+    assert grammar.parse("G1 X9.495 Y-7.533 Z0.6 F30000\n")
+    ast = grammar.parse("G1 X9.495 Y-7.533 Z0.6 F30000\n")
+
+    transformer = ToolpathTransformer(ZERO_OFFSET)
+    with raises(VisitationError) as error_message:
+        transformer.visit(ast)
+
+    assert "Three-axis move" in str(error_message)


### PR DESCRIPTION
Write a test case to ensure that the input `G1 X Y Z F` is successfully decoded. Also ensure that the conversion is terminated with `NotImplementedError`. Scan the error message. Ensure the error message mentions a human-readable message:

```
Three-axis move command not supported: "G1 X9.495 Y-7.533 Z0.6 F30000"

Did you forget to disable the "sequential printing mode"?
Reference: https://help.prusa3d.com/article/sequential-printing_124589
```

Resolves: #16  