### PR TITLE
Terminate on arc move (G2/G3) command

### DIFF
--- a/mbotmake2/grammars/toolpath.py
+++ b/mbotmake2/grammars/toolpath.py
@@ -5,13 +5,13 @@ from parsimonious.grammar import Grammar
 NOT_STRICT = (
     "Line = (Move / ResetPosition / FanDuty / FanOff "
     "/ ToolheadTemperature / BedTemperature / AbsolutePositioning / AbsolutePositioningForExtruders "
-    "/ Unsupported / Comment) InlineComment? newline\n\n"
+    "/ ArcMove / Unsupported / Comment) InlineComment? newline\n\n"
 )
 
 STRICT = (
     "Line = (Move / ResetPosition / FanDuty / FanOff "
     "/ ToolheadTemperature / BedTemperature / AbsolutePositioning / AbsolutePositioningForExtruders "
-    "/ Comment) InlineComment? newline\n\n"
+    "/ ArcMove / Comment) InlineComment? newline\n\n"
 )
 
 SYNTAX = r"""
@@ -25,7 +25,6 @@ ToolheadTemperature = "M104 S" Integer
 BedTemperature = "M140 S" Integer
 FanDuty = "M106 S" Decimal
 FanOff = "M107"
-Unsupported = ~r"[MG][0-9]+[^\n;]*"i
 
 AbsolutePositioning = "G90"
 AbsolutePositioningForExtruders = "M82"
@@ -36,6 +35,9 @@ CoordZ = Z Decimal Feedrate?
 Coord2D = X Decimal Y Decimal ExtruderPosition? Feedrate?
 Coord3D = X Decimal Y Decimal Z Decimal Feedrate?
 CoordE = ExtruderPosition Feedrate
+
+ArcMove = ~r"G[23] [^\n]*"
+Unsupported = ~r"[MG][0-9]+[^\n;]*"i
 
 ExtruderPosition = " E" Decimal
 Feedrate = " F" Decimal

--- a/mbotmake2/transformers/toolpath.py
+++ b/mbotmake2/transformers/toolpath.py
@@ -180,6 +180,12 @@ Reference: https://help.prusa3d.com/article/sequential-printing_124589
     def visit_Feedrate(self, _, visited_children) -> float:
         return visited_children[1] / 60.0
 
+    def visit_ArcMove(self, node, _) -> None:
+        raise NotImplementedError(f"""Arc move not implemented: {node.text:s}
+
+Please disable "Arc fitting" feature in the Slicer:
+Reference: https://wiki.bambulab.com/en/software/bambu-studio/acr-move""")
+
     def visit_ExtruderPosition(self, _, visited_children) -> Coords:
         _, value = visited_children
         return Coords(value, self.cursor.x - self.printer_offset.x, self.cursor.y - self.printer_offset.y)

--- a/tests/test_toolpath_parsing.py
+++ b/tests/test_toolpath_parsing.py
@@ -118,3 +118,15 @@ def test_3d_diagonal_move() -> None:
         transformer.visit(ast)
 
     assert "Three-axis move" in str(error_message)
+
+
+def test_arc_move() -> None:
+    assert grammar.parse("G2 X-11.086 Y3.526 I-18.508 J75.233 E.08589\n")
+    assert grammar.parse("G3 X-8.266 Y4.164 I.125 J-10.938 E.07193\n")
+
+    ast = grammar.parse("G3 X-8.266 Y4.164 I.125 J-10.938 E.07193\n")
+    transformer = ToolpathTransformer(ZERO_OFFSET)
+    with raises(VisitationError) as error_message:
+        transformer.visit(ast)
+
+    assert "Arc move" in str(error_message)


### PR DESCRIPTION
`mbotmake` does not yet support arc move commands. Capture the first occurrence of G2/G3 commands and then raise the `NotImplementedError`. 

Related: #17 , #16 .