### PR TITLE
Report YZ and XYZ move as NotImplementedException

### DIFF
--- a/mbotmake2/grammars/toolpath.py
+++ b/mbotmake2/grammars/toolpath.py
@@ -33,7 +33,7 @@ ResetPosition = "G92 E" ("0.0" / "0")
 Move = "G1" (Coord3D / Coord2D / CoordE / CoordZ / Feedrate)
 CoordZ = Z Decimal Feedrate?
 Coord2D = X Decimal Y Decimal ExtruderPosition? Feedrate?
-Coord3D = X Decimal Y Decimal Z Decimal Feedrate?
+Coord3D = (X Decimal)? Y Decimal Z Decimal Feedrate?
 CoordE = ExtruderPosition Feedrate
 
 ArcMove = ~r"G[23] [^\n]*"

--- a/mbotmake2/transformers/toolpath.py
+++ b/mbotmake2/transformers/toolpath.py
@@ -145,10 +145,10 @@ class ToolpathTransformer(NodeVisitor):
         )
 
     def visit_Coord3D(self, node, _) -> None:
-        raise NotImplementedError(f"""Three-axis move command not supported: {node.text:s}
+        raise NotImplementedError(f"""Joint Z and XY move command not supported: {node.text:s}
 
-Did you forget to disable the "sequential printing mode"?
-Reference: https://help.prusa3d.com/article/sequential-printing_124589
+Spiral vase printing is not yet supported.
+Reference: https://wiki.bambulab.com/en/software/bambu-studio/spiral-vase
 """)
 
     def visit_Coord2D(self, _, visited_children) -> Coords:

--- a/tests/test_toolpath_parsing.py
+++ b/tests/test_toolpath_parsing.py
@@ -117,7 +117,18 @@ def test_3d_diagonal_move() -> None:
     with raises(VisitationError) as error_message:
         transformer.visit(ast)
 
-    assert "Three-axis move" in str(error_message)
+    assert "Joint Z and XY move" in str(error_message)
+
+
+def test_yz_diagonal_move() -> None:
+    assert grammar.parse("G1 Y-7.533 Z0.6 F30000\n")
+    ast = grammar.parse("G1 Y-7.533 Z0.6 F30000\n")
+
+    transformer = ToolpathTransformer(ZERO_OFFSET)
+    with raises(VisitationError) as error_message:
+        transformer.visit(ast)
+
+    assert "Joint Z and XY move" in str(error_message)
 
 
 def test_arc_move() -> None:


### PR DESCRIPTION
When gcode: `G1 Y0.3 Z0.1 F5000` is detected, parse it as `Coord3D` token in the grammar. Denote the error as `NotImplementedException`. Indicate that spiral vase printing mode is work in progress.

Related to: #24 .